### PR TITLE
Fix alt text in BenefitSection

### DIFF
--- a/src/components/Benefits/BenefitSection.tsx
+++ b/src/components/Benefits/BenefitSection.tsx
@@ -90,7 +90,7 @@ const BenefitSection: React.FC<Props> = ({ benefit, imageAtRight }: Props) => {
                     <div className={clsx("w-fit flex", { "justify-start": imageAtRight, "justify-end": !imageAtRight })}>
                         <Image
                             src={imageSrc}
-                            alt="title"
+                            alt={title}
                             width={400}  // Increased image width
                             height={1000}  // Increased image height
                             quality={100}


### PR DESCRIPTION
## Summary
- show benefit titles in image alt text for better accessibility

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864e7fc301c832f9f0b56867b0f45f7